### PR TITLE
Remove unnecessary association in trip model

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,5 +1,4 @@
 class Trip < ApplicationRecord
-  belongs_to :country
   belongs_to :user
 
   belongs_to :origin, :class_name => 'Country'


### PR DESCRIPTION
We don't need to specify that trip belongs to country because
we've already said that it can belong to origin or destination.