### PR TITLE
Trips index page

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -77,6 +77,6 @@
 .trips-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-gap: 24px;
+  grid-gap: 36px;
 
 }

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -1,13 +1,14 @@
 <div class="container-fluid">
   <div class="row justify-content-center my-5">
     <div class="col-10">
+
       <h1 class="text-center">My trips</h1>
-      <div class="d-flex align-items-center bg-white my-3 px-3">
+      <div class="d-flex justify-content-end align-items-center bg-white my-4 mr-2">
         <%= link_to root_path do %>
-          <div class="">
-            <i class="far fa-plus-square"></i>
-            <strong>New trip</strong>
-          </div>
+          <!-- <div class=""> -->
+            <!-- <i class="far fa-plus-square"></i> -->
+            <span class="btn btn-falcony mb-2">New search</span>
+          <!-- </div> -->
         <% end %>
       </div>
 
@@ -16,7 +17,7 @@
             <div class="card card-shadow">
               <%= link_to trip_path(trip) do %>
                 <%= image_tag ("https://source.unsplash.com/1600x900/?#{trip.destination.name},landscape"), :class => "card-img-top" %>
-                <div class="card-body d-flex justify-content-around align-items-center p-3">
+                <div class="card-body d-flex justify-content-between align-items-center p-3 mx-1">
                   <div class="flex-grow-1">
                     <p class="card-text"><%= trip.origin.name %> - <%= trip.destination.name %></p>
                   </div>
@@ -31,6 +32,7 @@
             </div>
         <% end %>
       </div>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
- btn-falcony instead of "+ new trip"
- margin bottom from button
- now on right for simmetry with other pages
- correct margins on text shown
- grid space 36 instead of 24