### PR TITLE
Change the action on the icon from patch to delete

### DIFF
--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -23,7 +23,7 @@
                   </div>
                   <div>
                     <!-- Link to unbookmark the trip -->
-                    <%= link_to trip_path(trip), method: :patch, remote: :true do %>
+                    <%= link_to trip_path(trip), method: :delete, remote: :true do %>
                       <i class="fas fa-bookmark card-text-countries-name"></i>
                     <% end %>
                   </div>


### PR DESCRIPTION
Changed it so when, you're on the trips index page and you click
to unbookmark you delete the trip and stay on the same page.