### PR TITLE
Make avatar image optional on sign up

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_many :trips, dependent: :destroy
   has_one_attached :photo
 
-  validates :photo, presence: true
+  validates :photo, presence: false
   validates :phone_number, phone: true
 
   private

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,7 +2,11 @@
   <div class="row justify-content-center">
     <div class="col-10 col-md-5 p-3" style="background-color: white;">
       <h2>Edit <%= resource_name.to_s.humanize %> Profile</h2>
-      <%= cl_image_tag current_user.photo.key, width: 200, crop: :fill, radius: :max %>
+      <% if current_user.photo.attached? %>
+        <%= cl_image_tag current_user.photo.key, width: 200, crop: :fill, radius: :max %>
+      <% else %>
+        <%= cl_image_tag ('https://res.cloudinary.com/dybiixki8/image/upload/v1600063129/falcony/default_avatar_hlklvm.png'), width: 200, crop: :fill, radius: :max %>
+      <% end %>
 
       <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <%= f.error_notification %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,7 +10,7 @@
         <div class="form-inputs">
         <!--  note: still need to add country form for choosing home-country -->
           <%= f.input :photo, as: :file,
-                      required: true %>
+                      required: false %>
           <%= f.input :first_name,
                       required: true,
                       autofocus: true,
@@ -20,7 +20,6 @@
                       autofocus: true,
                       input_html: { autocomplete: "Last name" }%>
           <%= f.input :phone_number,
-                      required: true,
                       autofocus: true,
                       input_html: { autocomplete: "Phone Number" }%>
           <%= f.input :email,

--- a/app/views/shared/_desktop_navbar.html.erb
+++ b/app/views/shared/_desktop_navbar.html.erb
@@ -20,7 +20,11 @@
         </li>
 
         <li class="nav-item dropdown">
-          <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% if current_user.photo.attached? %>
+            <%= cl_image_tag current_user.photo.key, class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% else %>
+            <%= cl_image_tag ('https://res.cloudinary.com/dybiixki8/image/upload/v1600063129/falcony/default_avatar_hlklvm.png'), class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+          <% end %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%= link_to "Settings", edit_user_registration_path(current_user), class: "dropdown-item" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>


### PR DESCRIPTION
Changed the user model to validate presence: false on :photo.
Removing it altogether didn't work because of the association
'has_one_attached: :photo'. By default ActiveStorage would
require a photo to be present.
Removed the requirement to have upload a photo on the new
registration form.
Updated the settings view and the navbar to display a basic
avatar when current_user.photo.attached? is false.