### PR TITLE
change-case-logic-to-only-update-latest

### DIFF
--- a/app/jobs/update_cases_job.rb
+++ b/app/jobs/update_cases_job.rb
@@ -8,7 +8,7 @@ class UpdateCasesJob < ApplicationJob
     require 'json'
 
     countries = [["AUT", "Austria"], ["BEL", "Belgium"], ["BGR", "Bulgaria"], ["HRV", "Croatia"], ["CYP", "Cyprus"], ["CZE", "Czech Republic"], ["DNK", "Denmark"], ["EST", "Estonia"], ["FIN", "Finland"], ["FRA", "France"], ["DEU", "Germany"], ["GRC", "Greece"], ["HUN", "Hungary"], ["ISL", "Iceland"], ["IRL", "Ireland"], ["ITA", "Italy"], ["LVA", "Latvia"], ["LTU", "Lithuania"], ["LUX", "Luxembourg"], ["MLT", "Malta"], ["NLD", "Netherlands"], ["NOR", "Norway"], ["POL", "Poland"], ["PRT", "Portugal"], ["ROU", "Romania"], ["SVK", "Slovakia"], ["SVN", "Slovenia"], ["ESP", "Spain"], ["SWE", "Sweden"], ["CHE", "Switzerland"]]
-    Case.destroy_all
+    # Case.destroy_all
 
     url = 'https://covid.ourworldindata.org/data/owid-covid-data.json'
     cases_serialized = open(url).read
@@ -17,8 +17,9 @@ class UpdateCasesJob < ApplicationJob
     countries.each do |country|
       # iso code: country[0]
       cases[country[0]]['data'].each do |covid_data|
+        # only create new cases for dates that doesn't yet exist in the database
         date = Date.parse(covid_data['date'])
-        if date > Date.new(2020, 3, 15)
+        if date > Case.last.date
         Case.create!(
           date: date,
           country: Country.find_by(iso: country[0]),


### PR DESCRIPTION
- changed the date in if statement that new case is only created when
date is bigger then yesterdays date
- commented out the destroy_all
- it`s better like this because if the loading for some reason doesn't
work we still have the data from the last days and the page doesn't break